### PR TITLE
test: add html and lcov reporters

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -27,9 +27,12 @@ module.exports = function (config) {
     },
 
     coverageReporter: {
-      type: 'text',
-      dir: 'coverage/',
-      file: 'coverage.txt',
+      dir: 'coverage',
+      reporters: [
+        { type: 'html', subdir: 'report-html' },
+        { type: 'lcov', subdir: 'report-lcov' },
+        { type: 'text', subdir: 'report-text' }
+      ],
       check: {
         global: {
           statements: 100,


### PR DESCRIPTION
Adds HTML and LCOV reporters. HTML is useful for debugging, LCOV is useful in some tools we may want to use in the future.